### PR TITLE
make the use of the spec recipe configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default.logstash_forwarder.version = '0.3.1'
+default.logstash_forwarder.enable_spec = true
 default.logstash_forwarder.config_file = '/etc/logstash-forwarder'
 default.logstash_forwarder.user = 'root'
 default.logstash_forwarder.group = 'root'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,5 +72,6 @@ service 'logstash-forwarder' do
   action [ :enable, :start ]
 end
 
-
-include_recipe 'logstash_forwarder::spec'
+if node['logstash_forwarder']['enable_spec']
+  include_recipe 'logstash_forwarder::spec'
+end


### PR DESCRIPTION
Adds a new boolean attribute that can be used to disable the use of the 'spec' recipe by the 'default' recipe. 

I made this change because I am already managing the sensu client from the sensu cookbook, and the spec recipe of this logstash_forwarder cookbook is also trying to modify /etc/sensu/conf.d/client.json which causes the sensu client to be restarted on every chef run as these 2 cookbooks both modify that file during every run. 

Default behavior is still to include the recipe, as before. 
